### PR TITLE
Update family-plan.md

### DIFF
--- a/docs/kagi/plans/family-plan.md
+++ b/docs/kagi/plans/family-plan.md
@@ -6,18 +6,18 @@ The Kagi Family Plan is perfect for families wanting to search smarter, emphasiz
 
 **Table of Contents**
 
-- [How to Use the Kagi Family Plan](#using)
-- [Logging if for Kids](#kidslogin)
-- [Unique Features](#features)
-  - [Kid-Friendly Search Experience](#kidfriendly)
-  - [Parental Controls](#parental)
-  - [AI Question Answering](#ai)
+- [How to Use the Kagi Family Plan](#how-to-use-the-kagi-family-plan)
+- [Logging if for Kids](#logging-in-for-kids)
+- [Unique Features](#unique-features)
+  - [Kid-Friendly Search Experience](#kid-friendly-search-experience)
+  - [Parental Controls](#parental-controls)
+  - [AI Question Answering](#ai-question-answering)
   - [Lenses](#lenses)
-  - [Personalized Results](#pr)
-  - [New Illustrations](#illustrations)
-- [Story behind the Poop Avatar](#poopavatar)
+  - [Personalized Results](#personalized-results)
+  - [New Illustrations](#new-illustrations)
+- [Story behind the Poop Avatar](#story-behind-the-poop-avatar)
 
-## <a name="using"></a> How to Use the Kagi Family Plan
+## How to Use the Kagi Family Plan
 
 To sign up for the Family Plan, select the plan that fits your family's size and needs at Kagi [account creation](https://kagi.com/onboarding?p=choose_plan&plan=family).
 
@@ -42,21 +42,21 @@ The Billing screen has the overview of the plan and allows you to update payment
 <center><em>Billing screen</em></center>
 
 
-## <a name="kidslogin"></a> Logging in for Kids
+## Logging in for Kids
 
 To log-in kid accounts, just proceed to normal login on their device. Kids enter just their username and password is not needed.
 
 A verification email will be sent to the account owner. They can just click the link in the email to automatically log in the kid account, or enter the provided numerical code.
 
-## <a name="features"></a> Unique Features
+## Unique Features
 
 The Kagi Family Plan has unique features that make it perfect for families.
 
-<a name="kidfriendly"></a> **Kid-Friendly Search Experience**
+### Kid-Friendly Search Experience
 
 The Kagi Family Plan also includes a kid-friendly search experience that uses strict content filters to ensure children are not exposed to harmful content. Kid’s profile simplifies the search experience with larger text, icons, and content adjusted for kids.
 
-<a name="parental"></a> **Parental Controls**
+### Parental Controls
 
 The Kagi Family Plan comes with parental controls that let parents manage their children's search experience.
 
@@ -67,7 +67,7 @@ Kagi allows parents to toggle whether kids will have access to the search result
 
 Safe search filters exclude adult material from the search results.
 
-<a name="ai"></a> **AI Question Answering**
+### AI Question Answering
 
 AI tools can be beneficial for getting quick answers to common questions, but it's important to remember that they're not always accurate. As part of the Kagi Family Plan, we encourage families to talk to their kids about the potential risks and benefits of AI question-answering tools. It's important for kids to understand how these tools work and how to use them safely and responsibly in a way to nurture curiosity.
 
@@ -76,7 +76,7 @@ We added appropriate warnings for AI tools around the interface and a particular
 <img src="https://staticmedia.kagi.com/family/quick_answer.png" >
 <center><em>Instant answers for kids powered by AI</em></center>
 
-<a name="lenses"></a> **Lenses**
+### Lenses
 
 Lenses are a subset of search results that are restricted to a subset of whitelisted sites (up to 10 per lens). You can create and share multiple lenses, such as having a lens for Education, School work, or Entertainment and assign the default one to be used for searches. We allow you to export and import lenses to share with other community parents.
 
@@ -88,21 +88,21 @@ Parents can create lenses for children to ensure they have access to the resourc
 <img src="https://staticmedia.kagi.com/family/lens_create.png" >
 <center><em>Create a lens</em></center>
 
-<a name="pr"></a> **Personalized Results**
+### Personalized Results
 
 In addition to lenses, we include the ability for parents to completely block (ban) websites from showing in the results, or to promote useful sites. Up to 1,000 websites can be curated in this way.
 
 <img src="https://staticmedia.kagi.com/family/pr.png" >
 <center><em>Granular control over what appears in the search results</em></center>
 
-<a name="illustrations"></a> **New Illustrations**
+### New Illustrations
 
 Our mascot Doggo now has a lady friend, and we introduced several new and delightful illustrations throughout the interface.
 
 <img src="https://staticmedia.kagi.com/family/lady_doggo.png" >
 <center><em>Lady Doggo</em></center>
 
-## <a name="poopavatar"></a> Story behind the Poop Avatar
+## Story behind the Poop Avatar
 
 Our selection of avatars for kids includes a poop avatar (which most kids find really funny), and there's a reason why we made this choice that goes deeper than what meets the eye.
 


### PR DESCRIPTION
Updated table of contents anchor links for Family Plan page to accommodate Vitepress behavior, also removed anchor tags as they don't work with vitepress and changed bold headers to h3 headers so that vitepress would generate anchor tags for them automatically and we can link from table of contents.